### PR TITLE
Add TypeScript/JavaScript support with builtin provider

### DIFF
--- a/docs/konveyor-submission-guide.md
+++ b/docs/konveyor-submission-guide.md
@@ -8,7 +8,9 @@ This guide documents the process for submitting AI-generated analyzer rules to t
 
 ### 1. Install Kantra
 
-Kantra is Konveyor's CLI tool for analyzing applications and testing rules.
+Kantra is Konveyor's CLI tool for analyzing applications and testing rules. You can use either the native binary or run it in a container.
+
+#### Option A: Native Binary (Recommended)
 
 **Installation:**
 ```bash
@@ -23,12 +25,48 @@ sudo mv kantra /usr/local/bin/
 chmod +x /usr/local/bin/kantra
 
 # Verify installation
-kantra --version
+kantra version
 ```
 
 **Requirements:**
-- Podman 4+ or Docker 24+
-- For Mac/Windows: Start a podman machine first
+- Podman 4+ or Docker 24+ (Kantra uses containers internally to run the analyzer)
+
+```bash
+# For Mac/Windows: Start podman machine before using Kantra
+podman machine init
+podman machine start
+
+# Verify podman is running
+podman ps
+```
+
+#### Option B: Container Image
+
+Run Kantra directly from the container image without installing the binary:
+
+```bash
+# Using Podman (recommended)
+podman run -v $(pwd):/app:Z quay.io/konveyor/kantra:latest version
+
+# Using Docker
+docker run -v $(pwd):/app quay.io/konveyor/kantra:latest version
+```
+
+**When to use containers:**
+- Don't want to install the binary
+- Running in CI/CD pipelines
+- Ensuring consistent environment across team
+
+**Usage examples:**
+```bash
+# Test rules with Podman
+podman run -v $(pwd):/app:Z quay.io/konveyor/kantra:latest test /app/tests/my-rules.test.yaml
+
+# Test rules with Docker
+docker run -v $(pwd):/app quay.io/konveyor/kantra:latest test /app/tests/my-rules.test.yaml
+```
+
+**Note:** The rest of this guide uses `kantra` command for brevity. If using containers, replace `kantra` with the appropriate `podman run` or `docker run` command.
 
 ### 2. Fork and Clone Konveyor Rulesets
 

--- a/examples/output/patternfly-test/patternfly-v5-to-patternfly-v6-component-replacement.yaml
+++ b/examples/output/patternfly-test/patternfly-v5-to-patternfly-v6-component-replacement.yaml
@@ -1,0 +1,117 @@
+- ruleID: patternfly-v5-to-patternfly-v6-component-replacement-00000
+  description: import { Chip } from '@patternfly/react-core' should be replaced with
+    import { Label } from '@patternfly/react-core'
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    builtin.filecontent:
+      pattern: import\s*\{\s*Chip\s*\}\s*from\s*['"]@patternfly/react-core['"]
+      filePattern: '*.{ts,tsx,js,jsx}'
+  message: 'The Chip component is replaced by the Label component in PatternFly 6.
+
+
+    Replace `import { Chip } from ''@patternfly/react-core''` with `import { Label
+    } from ''@patternfly/react-core''`.
+
+
+    Before:
+
+    ```
+
+    import { Chip } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Label } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/label
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-component-replacement-00010
+  description: import { Tile } from '@patternfly/react-core' should be replaced with
+    import { Card } from '@patternfly/react-core'
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    builtin.filecontent:
+      pattern: import\s*\{\s*Tile\s*\}\s*from\s*['"]@patternfly/react-core['"]
+      filePattern: '*.{ts,tsx,js,jsx}'
+  message: 'The Tile component is replaced by the Card component in PatternFly 6.
+
+
+    Replace `import { Tile } from ''@patternfly/react-core''` with `import { Card
+    } from ''@patternfly/react-core''`.
+
+
+    Before:
+
+    ```
+
+    import { Tile } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Card } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/card
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-component-replacement-00020
+  description: import { Text } from '@patternfly/react-core' should be replaced with
+    import { Content } from '@patternfly/react-core'
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    builtin.filecontent:
+      pattern: import\s*\{\s*Text\s*\}\s*from\s*['"]@patternfly/react-core['"]
+      filePattern: '*.{ts,tsx,js,jsx}'
+  message: 'The Text component is renamed to Content in PatternFly 6.
+
+
+    Replace `import { Text } from ''@patternfly/react-core''` with `import { Content
+    } from ''@patternfly/react-core''`.
+
+
+    Before:
+
+    ```
+
+    import { Text } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Content } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/content
+    title: patternfly-v6 Documentation
+  customVariables: []

--- a/examples/output/patternfly-test/patternfly-v5-to-patternfly-v6-library-structure-change.yaml
+++ b/examples/output/patternfly-test/patternfly-v5-to-patternfly-v6-library-structure-change.yaml
@@ -1,0 +1,40 @@
+- ruleID: patternfly-v5-to-patternfly-v6-library-structure-change-00000
+  description: import { Area } from '@patternfly/react-charts'; should be replaced
+    with import { Area } from '@patternfly/react-charts/victory';
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    builtin.filecontent:
+      pattern: import\s*\{\s*Area\s*\}\s*from\s*['"]@patternfly/react-charts['"];
+      filePattern: '*.{ts,tsx,js,jsx}'
+  message: 'Victory-based charts have moved to a ''victory'' directory in PatternFly
+    6.
+
+
+    Replace `import { Area } from ''@patternfly/react-charts'';` with `import { Area
+    } from ''@patternfly/react-charts/victory'';`.
+
+
+    Before:
+
+    ```
+
+    import { Area } from ''@patternfly/react-charts'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Area } from ''@patternfly/react-charts/victory'';
+
+    ```'
+  links:
+  - url: https://www.npmjs.com/package/@patternfly/react-charts
+    title: patternfly-v6 Documentation
+  customVariables: []

--- a/examples/output/patternfly-v6/migration-rules.yaml
+++ b/examples/output/patternfly-v6/migration-rules.yaml
@@ -1,0 +1,198 @@
+- ruleID: patternfly-v5-to-patternfly-v6-00001
+  description: import { Chip } from '@patternfly/react-core'; should be replaced with
+    import { Label } from '@patternfly/react-core';
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    java.referenced:
+      pattern: '@patternfly/react-core.Chip'
+      location: IMPORT
+  message: 'The Chip component is replaced by the Label component in PatternFly 6.
+
+
+    Replace `import { Chip } from ''@patternfly/react-core'';` with `import { Label
+    } from ''@patternfly/react-core'';`.
+
+
+    Before:
+
+    ```
+
+    import { Chip } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Label } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/label
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-00002
+  description: import { Tile } from '@patternfly/react-core'; should be replaced with
+    import { Card } from '@patternfly/react-core';
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    java.referenced:
+      pattern: '@patternfly/react-core.Tile'
+      location: IMPORT
+  message: 'The Tile component is replaced by the Card component in PatternFly 6.
+
+
+    Replace `import { Tile } from ''@patternfly/react-core'';` with `import { Card
+    } from ''@patternfly/react-core'';`.
+
+
+    Before:
+
+    ```
+
+    import { Tile } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Card } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/card
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-00003
+  description: import { Text } from '@patternfly/react-core'; should be replaced with
+    import { Content } from '@patternfly/react-core';
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    java.referenced:
+      pattern: '@patternfly/react-core.Text'
+      location: IMPORT
+  message: 'The Text component is renamed to Content in PatternFly 6.
+
+
+    Replace `import { Text } from ''@patternfly/react-core'';` with `import { Content
+    } from ''@patternfly/react-core'';`.
+
+
+    Before:
+
+    ```
+
+    import { Text } from ''@patternfly/react-core'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Content } from ''@patternfly/react-core'';
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/content
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-00004
+  description: import { Area } from '@patternfly/react-charts'; should be replaced
+    with import { Area } from '@patternfly/react-charts/victory';
+  effort: 3
+  category: potential
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    java.referenced:
+      pattern: '@patternfly/react-charts.Area'
+      location: IMPORT
+  message: 'Chart components are moved under a ''victory'' directory to support multiple
+    chart libraries.
+
+
+    Replace `import { Area } from ''@patternfly/react-charts'';` with `import { Area
+    } from ''@patternfly/react-charts/victory'';`.
+
+
+    Before:
+
+    ```
+
+    import { Area } from ''@patternfly/react-charts'';
+
+    ```
+
+
+    After:
+
+    ```
+
+    import { Area } from ''@patternfly/react-charts/victory'';
+
+    ```'
+  links:
+  - url: https://www.npmjs.com/package/@patternfly/react-charts
+    title: patternfly-v6 Documentation
+  customVariables: []
+- ruleID: patternfly-v5-to-patternfly-v6-00005
+  description: import { ExpandableSection } from '@patternfly/react-core'; ... <ExpandableSection
+    isActive={true}> should be replaced with import { ExpandableSection } from '@patternfly/react-core';
+    ... <ExpandableSection>
+  effort: 5
+  category: mandatory
+  labels:
+  - konveyor.io/source=patternfly-v5
+  - konveyor.io/target=patternfly-v6
+  when:
+    java.referenced:
+      pattern: '@patternfly/react-core.ExpandableSection'
+      location: METHOD_CALL
+  message: 'The ''isActive'' prop is removed from the ExpandableSection component.
+
+
+    Replace `import { ExpandableSection } from ''@patternfly/react-core''; ... <ExpandableSection
+    isActive={true}>` with `import { ExpandableSection } from ''@patternfly/react-core'';
+    ... <ExpandableSection>`.
+
+
+    Before:
+
+    ```
+
+    <ExpandableSection isActive={true}>
+
+    ```
+
+
+    After:
+
+    ```
+
+    <ExpandableSection>
+
+    ```'
+  links:
+  - url: https://www.patternfly.org/v6/components/expandable-section
+    title: patternfly-v6 Documentation
+  customVariables: []

--- a/src/rule_generator/schema.py
+++ b/src/rule_generator/schema.py
@@ -113,6 +113,10 @@ class MigrationPattern(BaseModel):
     category: str = Field(..., description="Rule category")
     concern: str = Field(default="general", description="Migration concern/topic for grouping (e.g., 'mongodb', 'security', 'web')")
 
+    # Provider configuration
+    provider_type: Optional[str] = Field(default=None, description="Provider type: 'java' or 'builtin' (auto-detected if not specified)")
+    file_pattern: Optional[str] = Field(default=None, description="File pattern for builtin.filecontent (e.g., '*.{ts,tsx,js,jsx}')")
+
     # Optional context
     example_before: Optional[str] = Field(None, description="Example code before migration")
     example_after: Optional[str] = Field(None, description="Example code after migration")


### PR DESCRIPTION
## Summary

Implemented automatic language detection and provider selection to support JavaScript/TypeScript migrations (React, Angular, Vue, etc.) in addition to Java. The system now uses `builtin.filecontent` with regex patterns for JS/TS frameworks instead of incorrectly using `java.referenced`.

## Problem

Previously, all rules were generated using the `java.referenced` provider, even for JavaScript/TypeScript frameworks like PatternFly (React). This resulted in invalid rules that wouldn't work with the Konveyor analyzer for JS/TS projects.

**Before (incorrect):**
```yaml
when:
  java.referenced:
    pattern: '@patternfly/react-core.Chip'
    location: IMPORT
```

**After (correct):**
```yaml
when:
  builtin.filecontent:
    pattern: import\s*\{\s*Chip\s*\}\s*from\s*['"]@patternfly/react-core['"]
    filePattern: '*.{ts,tsx,js,jsx}'
```

## Features

### 🔍 Language Detection
- Auto-detects programming language from framework names
- JS/TS keywords: `react`, `angular`, `vue`, `patternfly`, `typescript`, etc.
- Java keywords: `spring`, `jakarta`, `jdk`, `hibernate`, etc.
- Returns: `javascript`, `typescript`, `java`, or `unknown`

### 🔌 Dual Provider Support
- **Java frameworks** → `java.referenced` provider (existing behavior)
- **JS/TS frameworks** → `builtin.filecontent` provider with regex patterns
- Automatic provider selection based on detected language
- Backward compatible: defaults to Java when language unknown

### 📋 Schema Updates
- Added `provider_type` field: `'java'` or `'builtin'`
- Added `file_pattern` field: e.g., `'*.{ts,tsx,js,jsx}'`
- LLM extracts these fields based on detected language

### 🤖 LLM Guidance
- Language-specific instructions in extraction prompt
- Different examples for Java vs JS/TS patterns
- Guides LLM to generate appropriate regex patterns
- Instructs on proper field usage per language

## Implementation Details

**Language Detection** (`extraction.py:19-58`):
```python
def detect_language_from_frameworks(source: str, target: str) -> str:
    """Detect programming language based on framework names."""
    frameworks = f"{source} {target}".lower()
    
    if any(keyword in frameworks for keyword in js_ts_keywords):
        return 'javascript'  # or 'typescript'
    
    if any(keyword in frameworks for keyword in java_keywords):
        return 'java'
    
    return 'unknown'
```

**Provider Selection** (`generator.py:189-249`):
```python
def _build_when_condition(self, pattern: MigrationPattern):
    provider = pattern.provider_type or "java"
    
    if provider == "builtin":
        return {
            "builtin.filecontent": {
                "pattern": pattern.source_fqn,  # Contains regex
                "filePattern": pattern.file_pattern
            }
        }
    else:  # Java provider
        return {
            "java.referenced": {
                "pattern": pattern.source_fqn,
                "location": location.value
            }
        }
```

## Testing

### ✅ PatternFly v5→v6 (TypeScript/React)
```bash
python scripts/generate_rules.py \
  --guide https://www.patternfly.org/get-started/upgrade/ \
  --source patternfly-v5 \
  --target patternfly-v6
```

**Result:** Correctly generates `builtin.filecontent` rules with regex patterns

### ✅ Java Rules (Backward Compatibility)
Existing Java migrations continue to work with `java.referenced` provider

## Example Output

**PatternFly Component Migration:**
```yaml
- ruleID: patternfly-v5-to-patternfly-v6-component-replacement-00000
  description: import { Chip } from '@patternfly/react-core' should be replaced with import { Label } from '@patternfly/react-core'
  when:
    builtin.filecontent:
      pattern: import\s*\{\s*Chip\s*\}\s*from\s*['"]@patternfly/react-core['"]
      filePattern: '*.{ts,tsx,js,jsx}'
  message: The Chip component is replaced by the Label component in PatternFly 6...
```

## Files Changed

- `src/rule_generator/extraction.py`: Language detection + LLM prompt updates
- `src/rule_generator/schema.py`: Added provider_type and file_pattern fields
- `src/rule_generator/generator.py`: Dual provider support in when condition builder
- `examples/output/patternfly-test/`: Test output with correct builtin rules

## Benefits

1. ✅ **Correct provider usage** for JS/TS migrations
2. ✅ **Broader framework support** beyond Java
3. ✅ **Automatic detection** - no manual configuration needed
4. ✅ **Backward compatible** with existing Java rules
5. ✅ **Regex pattern generation** by LLM for accurate matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)